### PR TITLE
if：重构检查逻辑

### DIFF
--- a/assets/custom/action/basics/Identify.py
+++ b/assets/custom/action/basics/Identify.py
@@ -3,49 +3,45 @@ from maa.custom_action import CustomAction
 
 
 class Identify(CustomAction):
-    def run(
-        self, context: Context, argv: CustomAction.RunArg
-    ) -> CustomAction.RunResult:
+    def run(self, context: Context, argv: CustomAction.RunArg) -> CustomAction.RunResult:
         image = context.tasker.controller.post_screencap().wait().get()
-        if context.run_recognition("检查终焉", image):
-            context.override_pipeline(
-                {
-                    "识别人物": {"enabled": False},
-                    "战斗中": {"action": "Custom", "custom_action": "Oblivion"},
-                }
-            )
-            print("终焉战斗")
-        elif context.run_recognition("检查深痕", image):
-            context.override_pipeline(
-                {
-                    "识别人物": {"enabled": False},
-                    "战斗中": {"action": "Custom", "custom_action": "Stigmata"},
-                }
-            )
-            print("深痕战斗")
-        elif context.run_recognition("检查深谣", image):
-            context.override_pipeline(
-                {
-                    "识别人物": {"enabled": False},
-                    "战斗中": {"action": "Custom", "custom_action": "LostLullaby"},
-                }
-            )
-            print("深谣战斗")
-        elif context.run_recognition("检查深红囚影", image):
-            context.override_pipeline(
-                {
-                    "识别人物": {"enabled": False},
-                    "战斗中": {"action": "Custom", "custom_action": "CrimsonWeave"},
-                }
-            )
-            print("深红囚影")
-        elif context.run_recognition("检查誓焰", image):
-            context.override_pipeline(
-                {
-                    "识别人物": {"enabled": False},
-                    "战斗中": {"action": "Custom", "custom_action": "Pyroath"},
-                }
-            )
-            print("誓焰战斗")
 
+        role_action_mapping = {
+            "终焉": "Oblivion",
+            "深痕": "Stigmata",
+            "深谣": "LostLullaby",
+            "深红囚影": "CrimsonWeave",
+            "誓焰": "Pyroath",
+        }
+
+        # 识别三位角色名
+        recognition_results = {
+            "first_role_name": context.run_recognition("识别第一位角色名", image).best_result.text,
+            "second_role_name": context.run_recognition("识别第二位角色名", image).best_result.text,
+            "third_role_name": context.run_recognition("识别第三位角色名", image).best_result.text,
+        }
+
+        # 检查哪些角色名在映射中，并构建matched_roles字典
+        matched_roles = {}
+        for key, role_name in recognition_results.items():
+            if role_name in role_action_mapping:
+                # 这里存储的是映射后的动作，而不是角色名，例：key:first_role_name，value:Oblivion
+                matched_roles[key] = role_action_mapping[role_name]
+
+        # 处理单个角色匹配的情况
+        if len(matched_roles) == 1:
+            # 获取动作名
+            role_key, role_value = next(iter(matched_roles.items()))  # 获取字典中的一个项（键，值）
+            context.override_pipeline(
+                {
+                    "识别人物": {"enabled": False},
+                    "战斗中": {"action": "Custom", "custom_action": role_action_mapping[role_value]},
+                }
+            )
+
+        # 处理多个角色匹配的情况
+        elif len(matched_roles) > 1:
+            pass
+        else:
+            print("No matched roles for teaming up.")
         return CustomAction.RunResult(success=True)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b9d26975-0f7c-4bac-ba27-ec7f13178f4d)
如果重构的话，你那些检查角色，识别任务的json就要改了，前面还得加个任务识别是否在组队界面，点击进这里面识别，识别三个角色名也需要json，或者就直接在Identify这个里面进行识别点击操做，role_action_mapping 的key还得看下识别值，不重构也没法匹配多人组队吧，啧