### PR TITLE
修复通行证任务无法处理以下描述界面的问题

### DIFF
--- a/assets/resource/base/pipeline/Battle_Pass.json
+++ b/assets/resource/base/pipeline/Battle_Pass.json
@@ -15,14 +15,16 @@
         "recognition": {
             "type": "OCR",
             "param": {
-                "roi": [
-                    734,
-                    479,
-                    80,
-                    44
-                ],
-                "expected": [
-                    "确认"
+        "roi": [
+            712,
+            443,
+            265,
+            103
+        ],
+        "recognition": "OCR",
+        "expected": [
+            "确定",
+            "確定"
                 ]
             }
         },


### PR DESCRIPTION
系统自动领取
部分评定任务已经刷新，系统自动为指挥官领取已完成评定任务的情报值奖励如下
                                                          确定
                                                          
                                                          

佬，俺不知道网页版咋拉取主仓库主分支过去（）