### PR TITLE
fix:修复macOS 启动GUI在战斗中因为print导致战斗终止的问题

### DIFF
--- a/assets/custom/action/exclusives/Crepuscule.py
+++ b/assets/custom/action/exclusives/Crepuscule.py
@@ -46,6 +46,8 @@ class Crepuscule(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
+
+        logger = logging.getLogger(f"{self._role_name}_Job")
         try:
             lens_lock = JobExecutor(
                 CombatActions.lens_lock(context),
@@ -75,7 +77,7 @@ class Crepuscule(CustomAction):
             )
             lens_lock.execute()
             if CombatActions.check_Skill_energy_bar(context, self._role_name):
-                print("大招就绪")
+                logger.info("大招就绪")
                 use_skill.execute()
             elif CombatActions.check_status(
                             context, "检查核心被动_晖暮", self._role_name
@@ -85,7 +87,7 @@ class Crepuscule(CustomAction):
                     1212,513, 1212,513, 3000
                 ).wait()   
             else:
-                print("核心技能未就绪")
+                logger.info("核心技能未就绪")
                 for _ in range(5):
                     attack.execute()
                     time.sleep(0.1)

--- a/assets/custom/action/exclusives/Hyperreal.py
+++ b/assets/custom/action/exclusives/Hyperreal.py
@@ -52,12 +52,16 @@ class Hyperreal(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
+
+        logger = logging.getLogger(f"{self._role_name}_Job")
+
         try:
             def get_ball_target():
                 return CombatActions.Arrange_Signal_Balls(
                     context,
                     "any",
                     self.tempelate,
+                    role_name=self._role_name,
                 )
 
             lens_lock = JobExecutor(
@@ -84,13 +88,13 @@ class Hyperreal(CustomAction):
             lens_lock.execute()
 
             if CombatActions.check_Skill_energy_bar(context, self._role_name):
-                print("大招就绪")
+                logger.info("大招就绪")
                 use_skill.execute()  # 在时间的尽头,湮灭吧
                 time.sleep(1)
             elif CombatActions.check_status(
                 context, "检查核心技能_超刻", self._role_name
             ):  # 核心技能就绪
-                print("核心技能就绪")
+                logger.info("核心技能就绪")
                 long_press_attack.execute()
                 start_time = time.time()
                 while CombatActions.check_status(
@@ -99,9 +103,9 @@ class Hyperreal(CustomAction):
                     target = get_ball_target()
                     CombatActions.ball_elimination_target(context, target)()
                     attack.execute()
-                print("核心技能结束")
+                logger.info("核心技能结束")
             else:
-                print("核心技能未就绪")
+                logger.info("核心技能未就绪")
                 for _ in range(5):
                     attack.execute()
                     time.sleep(0.1)

--- a/assets/custom/action/exclusives/LostLullaby.py
+++ b/assets/custom/action/exclusives/LostLullaby.py
@@ -46,6 +46,8 @@ class LostLullaby(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
+
+        logger = logging.getLogger(f"{self._role_name}_Job")
         try:
             lens_lock = JobExecutor(
                 CombatActions.lens_lock(context),
@@ -102,7 +104,7 @@ class LostLullaby(CustomAction):
 
             lens_lock.execute()
             if CombatActions.check_status(context, "检查阶段p1_深谣", self._role_name):
-                print("p1阶段")
+                logger.info("p1阶段")
                 if CombatActions.check_Skill_energy_bar(context, self._role_name):
                     start_time = time.time()
                     while time.time() - start_time < 1:
@@ -114,7 +116,7 @@ class LostLullaby(CustomAction):
                     if CombatActions.check_status(
                         context, "检查核心被动2_深谣", self._role_name
                     ):
-                        print("p1核心被动2")
+                        logger.info("p1核心被动2")
                         start_time = time.time()
                         while time.time() - start_time < 1:
                             time.sleep(0.1)
@@ -131,7 +133,7 @@ class LostLullaby(CustomAction):
                     if CombatActions.check_status(
                         context, "检查核心被动1_深谣", self._role_name
                     ):
-                        print("p1核心被动1")
+                        logger.info("p1核心被动1")
                         ball_elimination.execute()
                         time.sleep(0.1)
                         dodge.execute()  # 闪避
@@ -143,7 +145,7 @@ class LostLullaby(CustomAction):
                             time.sleep(0.1)
                             attack.execute()  # 攻击
                     else:
-                        print("没有核心被动")
+                        logger.info("没有核心被动")
                         start_time = time.time()
                         while time.time() - start_time < 2:
                             time.sleep(0.1)
@@ -153,9 +155,9 @@ class LostLullaby(CustomAction):
             elif CombatActions.check_status(
                 context, "检查阶段p2_深谣", self._role_name
             ):
-                print("p2阶段")
+                logger.info("p2阶段")
                 if CombatActions.check_Skill_energy_bar(context, self._role_name):
-                    print("释放技能")
+                    logger.info("释放技能")
                     start_time = time.time()
                     while time.time() - start_time < 1:
                         time.sleep(0.1)
@@ -171,7 +173,7 @@ class LostLullaby(CustomAction):
                     if CombatActions.check_status(
                         context, "检查核心被动2_深谣", self._role_name
                     ):
-                        print("p2核心被动2")
+                        logger.info("p2核心被动2")
                         start_time = time.time()
                         while time.time() - start_time < 1:
                             time.sleep(0.1)
@@ -204,7 +206,7 @@ class LostLullaby(CustomAction):
                                 use_skill.execute()  # 沉没在,这片海底
                             time.sleep(1.5)
                     else:
-                        print("没有核心被动")
+                        logger.info("没有核心被动")
                         start_time = time.time()
                         while time.time() - start_time < 1.5:
                             time.sleep(0.3)

--- a/assets/custom/action/exclusives/Pyroath.py
+++ b/assets/custom/action/exclusives/Pyroath.py
@@ -46,6 +46,9 @@ class Pyroath(CustomAction):
     def run(
         self, context: Context, argv: CustomAction.RunArg
     ) -> CustomAction.RunResult:
+
+        logger = logging.getLogger(f"{self._role_name}_Job")
+
         try:
             lens_lock = JobExecutor(
                 CombatActions.lens_lock(context),
@@ -96,11 +99,11 @@ class Pyroath(CustomAction):
             lens_lock.execute()
 
             if CombatActions.check_status(context, "检查u1_誓焰", self._role_name):
-                print("誓焰u1")
+                logger.info("誓焰u1")
                 if CombatActions.check_status(
                     context, "检查p1动能条_誓焰", self._role_name
                 ):
-                    print("p1动能条max")
+                    logger.info("p1动能条max")
 
                     long_press_skill.execute()  # 汇聚,阳炎之光
                     time.sleep(2)
@@ -117,7 +120,7 @@ class Pyroath(CustomAction):
                         ):
                             use_skill.execute()  # 进入u3阶段
                 else:
-                    print("p1动能条非max")
+                    logger.info("p1动能条非max")
                     ball_elimination_second.execute()  # 消球2
                     start_time = time.time()
                     while time.time() - start_time < 2:
@@ -125,11 +128,11 @@ class Pyroath(CustomAction):
                         attack.execute()
 
             if CombatActions.check_status(context, "检查u3_誓焰", self._role_name):
-                print("誓焰u3")
+                logger.info("誓焰u3")
                 if CombatActions.check_status(
                     context, "检查p1动能条_誓焰", self._role_name
                 ):
-                    print("p3动能条max")
+                    logger.info("p3动能条max")
                     long_press_attack = JobExecutor(
                         CombatActions.long_press_attack(context, 4000),
                         GameActionEnum.LONG_PRESS_ATTACK,
@@ -147,14 +150,14 @@ class Pyroath(CustomAction):
                             trigger_qte_second.execute()
                             auxiliary_machine.execute()
                 else:
-                    print("p3动能条非max")
+                    logger.info("p3动能条非max")
                     start_time = time.time()
                     while time.time() - start_time < 2:
                         time.sleep(0.1)
                         attack.execute()  # 攻击
 
             if CombatActions.check_status(context, "检查u2_誓焰", self._role_name):
-                print("誓焰u2")
+                logger.info("誓焰u2")
                 ball_elimination_second.execute()  # 消球2
                 attack.execute()  # 攻击
                 use_skill.execute()  # 进入u3阶段

--- a/assets/custom/action/exclusives/Shukra.py
+++ b/assets/custom/action/exclusives/Shukra.py
@@ -75,7 +75,9 @@ class Shukra(CustomAction):
                 context,
                 "any",
                 self.tempelate,
+                role_name=self._role_name,
             )
+        logger = logging.getLogger(f"{self._role_name}_Job")
 
         try:
             lens_lock = JobExecutor(
@@ -116,18 +118,18 @@ class Shukra(CustomAction):
                     time.sleep(0.3)
                     target = get_ball_target()
                     CombatActions.ball_elimination_target(context, target)()
-                    print(f"初次消球")
+                    logger.info(f"初次消球")
                     if target > 0:
                         time.sleep(0.1)
-                        print(f"三连目标,开始二次消球")
+                        logger.info(f"三连目标,开始二次消球")
                         CombatActions.ball_elimination_target(context, 1)()  # 单独消球
                     elif target == 0:
-                        print(f"信号球空,结束")
+                        logger.info(f"信号球空,结束")
                         break
-                print(f"长按攻击")
+                logger.info(f"长按攻击")
                 long_press_attack.execute()
             else:
-                print(f"普攻")
+                logger.info(f"普攻")
                 start_time = time.time()
                 while time.time() - start_time < 2:
                     attack.execute()  # 攻击


### PR DESCRIPTION
macOS GUI启动
在战斗过程中因为print输出导致任务异常
<img width="738" height="92" alt="image" src="https://github.com/user-attachments/assets/31a094d4-76a7-4fb1-96cc-0a0be072c1d5" />
