### PR TITLE
fix: 界面未完成加载时点击资源标签

### DIFF
--- a/assets/resource/base/pipeline/daily_battle/Navigation.jsonc
+++ b/assets/resource/base/pipeline/daily_battle/Navigation.jsonc
@@ -68,8 +68,36 @@
             "type": "Click"
         },
         "next": [
-            "打开拟战场域"
+            "打开拟战场域",
+            "[JumpBack]检查_打开资源"
         ]
+    },
+    "检查_打开资源": {
+        "post_delay": 0,
+        "pre_delay": 0,
+        "rate_limit": 0,
+        "recognition": {
+            "type": "ColorMatch",
+            "param": {
+                "roi": [
+                    852,
+                    716,
+                    214,
+                    4
+                ],
+                "lower": [245, 245, 245],
+                "upper": [255, 255, 255],
+                "connected": true,
+                "count": 400
+            }
+        },
+        "inverse": true,
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": "打开资源"
+            }
+        }
     },
     "打开拟战场域": {
         "post_delay": 0,


### PR DESCRIPTION
fix: 界面未完成加载时点击资源标签

导致未进入`打开拟战场域`识别界面，任务失败