### PR TITLE
fix: 使FOS不会在战双（mumu模拟器）启动缓慢时频繁重启游戏。

### DIFF
--- a/resource/base/pipeline/Start_up.jsonc
+++ b/resource/base/pipeline/Start_up.jsonc
@@ -1,6 +1,7 @@
 {
     "启动": {
-        "timeout": 60000,
+        "timeout": 480000,
+		"on_error": ["[JumpBack]重启任务"],
         "next": [
             "[JumpBack]MAS联动处理-检查到维护公告_将发送假通知",
             "[JumpBack]关闭点击空白弹窗",
@@ -13,8 +14,7 @@
             "[JumpBack]更新中",
             "[JumpBack]返回主菜单",
             "[JumpBack]用户账号登录失败",
-            "[JumpBack]打开应用",
-            "[JumpBack]重启任务"
+            "[JumpBack]打开应用"
         ]
     },
     "游戏初始化": {


### PR DESCRIPTION
我的战双是安装在mumu模拟器上的，启动时间很长。FOS在执行进入游戏任务时，顺序执行每个jumpback节点的总时间不够长，每次都会在模拟器战双加载到登录界面的时候重启游戏。这导致FOS循环重启游戏而无法进入游戏。
为了解决这个问题，我把start_up.jsonc里的"重启任务"节点放到了on_error下，并将限制时间（timeout）设置到480秒。这样的话，只有当"next"下的节点持续识别失败超过480秒才会重启游戏。